### PR TITLE
Update CSV path to dynamic loading

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,10 @@ class Settings(BaseSettings):
     
     # Paths
     STORAGE_PATH: str = os.getenv("STORAGE_PATH", "/storage")
-    CSV_FILE_PATH: str = os.getenv("CSV_FILE_PATH", "/home/runner/workspace/Rozszerzona_tabela_opcji.csv")
+    
+    # Dynamic CSV file path - works locally and on Render
+    _base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    CSV_FILE_PATH: str = os.getenv("CSV_FILE_PATH", os.path.join(_base_dir, "Rozszerzona_tabela_opcji.csv"))
 
     # Security
     CORS_ORIGINS: list = ["http://localhost:5000", "http://localhost:8000"]


### PR DESCRIPTION
Fix: Dynamically load CSV file path to work on Render and locally.

The previous hardcoded path `/home/runner/workspace/Rozszerzona_tabela_opcji.csv` was environment-specific, causing issues when deployed to Render. This change calculates the path relative to the project root.